### PR TITLE
Fix: Remove unused import from grain-processor

### DIFF
--- a/src/grain-processor.ts
+++ b/src/grain-processor.ts
@@ -11,7 +11,6 @@ import {
   convertLinearFloatToSrgb,
   convertGrayscaleLinearToSingleChannel,
   applyBeerLambertCompositingGrayscale,
-  calculateGrainFalloffFromSquaredDistance,
 } from './grain-math';
 import { convertImageDataToGrayscale } from './color-space';
 import { createGrainExposure } from './types';


### PR DESCRIPTION
Removes the unused import of `calculateGrainFalloffFromSquaredDistance` from `src/grain-processor.ts` to resolve the CI linting error.